### PR TITLE
Allow selection of symbols

### DIFF
--- a/filekitty/app.py
+++ b/filekitty/app.py
@@ -1,11 +1,14 @@
+import ast
 import os
 
-from PyQt5.QtCore import QSettings, QTimer, Qt
-from PyQt5.QtGui import QIcon, QGuiApplication, QKeySequence, QDragEnterEvent, QDropEvent
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QIcon, QGuiApplication, QKeySequence
 from PyQt5.QtWidgets import (
     QApplication, QWidget, QFileDialog, QVBoxLayout, QPushButton, QTextEdit,
-    QLabel, QListWidget, QDialog, QLineEdit, QHBoxLayout, QAction, QMenuBar,
-    QGraphicsColorizeEffect
+    QLabel, QListWidget, QDialog, QAction, QMenuBar
+)
+from PyQt5.QtWidgets import (
+    QListWidgetItem
 )
 
 ICON_PATH = 'assets/icon/FileKitty-icon.png'
@@ -18,38 +21,50 @@ class PreferencesDialog(QDialog):
         self.initUI()
 
     def initUI(self):
-        layout = QVBoxLayout()
-
-        self.pathEdit = QLineEdit(self)
-        self.pathEdit.setPlaceholderText("Enter or select default file path...")
-        layout.addWidget(self.pathEdit)
-
-        btnBrowse = QPushButton("Browse...")
-        btnBrowse.clicked.connect(self.browsePath)
-        layout.addWidget(btnBrowse)
-
-        btnLayout = QHBoxLayout()
-        btnSave = QPushButton('Save')
-        btnCancel = QPushButton('Cancel')
-        btnLayout.addWidget(btnSave)
-        btnLayout.addWidget(btnCancel)
-
-        btnSave.clicked.connect(self.accept)
-        btnCancel.clicked.connect(self.reject)
-
-        layout.addLayout(btnLayout)
+        layout = QVBoxLayout(self)
         self.setLayout(layout)
 
-    def browsePath(self):
-        dir_path = QFileDialog.getExistingDirectory(self, "Select Default Directory")
-        if dir_path:
-            self.pathEdit.setText(dir_path)
 
-    def get_path(self):
-        return self.pathEdit.text()
+class SelectClassesFunctionsDialog(QDialog):
+    def __init__(self, classes, functions, selected_items=None, parent=None):
+        super(SelectClassesFunctionsDialog, self).__init__(parent)
+        self.setWindowTitle('Select Classes/Functions')
+        self.classes = classes
+        self.functions = functions
+        self.selected_items = selected_items if selected_items is not None else []
+        self.initUI()
 
-    def set_path(self, path):
-        self.pathEdit.setText(path)
+    def initUI(self):
+        layout = QVBoxLayout(self)
+
+        self.fileList = QListWidget(self)
+        for cls in self.classes:
+            item = QListWidgetItem(f"Class: {cls}")
+            item.setCheckState(Qt.Checked if cls in self.selected_items else Qt.Unchecked)
+            self.fileList.addItem(item)
+
+        for func in self.functions:
+            item = QListWidgetItem(f"Function: {func}")
+            item.setCheckState(Qt.Checked if func in self.selected_items else Qt.Unchecked)
+            self.fileList.addItem(item)
+
+        layout.addWidget(self.fileList)
+
+        self.btnOk = QPushButton('OK', self)
+        self.btnOk.clicked.connect(self.accept)
+        layout.addWidget(self.btnOk)
+
+        self.setLayout(layout)
+
+    def accept(self):
+        self.selected_items = [
+            item.text().split(": ")[1] for item in self.fileList.findItems("*", Qt.MatchWildcard)
+            if item.checkState() == Qt.Checked
+        ]
+        super().accept()
+
+    def get_selected_items(self):
+        return self.selected_items
 
 
 class FilePicker(QWidget):
@@ -58,7 +73,8 @@ class FilePicker(QWidget):
         self.setWindowTitle('FileKitty')
         self.setWindowIcon(QIcon(ICON_PATH))
         self.setGeometry(100, 100, 800, 600)
-        self.setAcceptDrops(True)
+        self.selected_items = []  # Track selected items
+        self.currentFiles = []  # Track current files
         self.initUI()
         self.createActions()
         self.createMenu()
@@ -76,14 +92,14 @@ class FilePicker(QWidget):
         self.lineCountLabel = QLabel('Lines ready to copy: 0', self)
         layout.addWidget(self.lineCountLabel)
 
-        self.btnRefresh = QPushButton('🔄 Refresh Text from Files', self)
-        self.btnRefresh.clicked.connect(self.refreshFiles)
-        self.btnRefresh.setEnabled(False)
-        layout.addWidget(self.btnRefresh)
-
         btnOpen = QPushButton('📂 Select Files', self)
         btnOpen.clicked.connect(self.openFiles)
         layout.addWidget(btnOpen)
+
+        self.btnSelectClassesFunctions = QPushButton('🔍 Select Classes/Functions', self)
+        self.btnSelectClassesFunctions.clicked.connect(self.selectClassesFunctions)
+        self.btnSelectClassesFunctions.setEnabled(False)
+        layout.addWidget(self.btnSelectClassesFunctions)
 
         self.btnCopy = QPushButton('📋 Copy to Clipboard', self)
         self.btnCopy.clicked.connect(self.copyToClipboard)
@@ -91,6 +107,8 @@ class FilePicker(QWidget):
         layout.addWidget(self.btnCopy)
 
         self.textEdit.textChanged.connect(self.updateCopyButtonState)
+
+        self.setLayout(layout)
 
     def createActions(self):
         self.prefAction = QAction("Preferences", self)
@@ -105,47 +123,37 @@ class FilePicker(QWidget):
 
     def showPreferences(self):
         dialog = PreferencesDialog(self)
-        dialog.set_path(self.get_default_path())
-        if dialog.exec_():
-            new_path = dialog.get_path()
-            self.set_default_path(new_path)
-
-    def get_default_path(self):
-        settings = QSettings('YourCompany', 'FileKitty')
-        return settings.value('defaultPath', '')
-
-    def set_default_path(self, path):
-        settings = QSettings('YourCompany', 'FileKitty')
-        settings.setValue('defaultPath', path)
+        dialog.exec_()
 
     def openFiles(self):
-        default_path = self.get_default_path() or ""
         options = QFileDialog.Options()
         files, _ = QFileDialog.getOpenFileNames(
-            self, "Select files to concatenate", default_path,
-            "All Files (*);;Text Files (*.txt)", options=options
+            self, "Select files to analyze", "",
+            "All Files (*);;Python Files (*.py);;JavaScript Files (*.js);;TypeScript Files (*.ts *.tsx)",
+            options=options
         )
         if files:
-            self.fileList.clear()
             self.currentFiles = files
-            self.refreshFiles()
-            self.btnRefresh.setEnabled(True)
-            concatenated_content = self.concatenate_files(files)
-            self.textEdit.setText(concatenated_content)
+            self.fileList.clear()
+            for file in files:
+                self.fileList.addItem(file)
 
-    def concatenate_files(self, files):
-        common_prefix = os.path.commonpath(files)
-        common_prefix = os.path.dirname(os.path.dirname(os.path.dirname(common_prefix)))
-        concatenated_content = ""
-        for file in files:
-            relative_path = os.path.relpath(file, start=common_prefix)
-            self.fileList.addItem(relative_path)
-            concatenated_content += f"### `{relative_path}`\n\n```\n"
-            with open(file, 'r', encoding='utf-8') as f:
-                content = f.read()
-                concatenated_content += content
-            concatenated_content += "\n```\n\n"
-        return concatenated_content.rstrip()
+            # Check if all selected files are Python files to enable the class/function selection
+            if all(file.endswith(('.py',)) for file in files):
+                self.btnSelectClassesFunctions.setEnabled(True)
+            else:
+                self.btnSelectClassesFunctions.setEnabled(False)
+
+            self.updateTextEdit()
+
+    def selectClassesFunctions(self):
+        if self.currentFiles:
+            file_path = self.currentFiles[0]
+            classes, functions, _, file_content = parse_python_file(file_path)
+            dialog = SelectClassesFunctionsDialog(classes, functions, self.selected_items, self)
+            if dialog.exec_():
+                self.selected_items = dialog.get_selected_items()
+                self.updateTextEdit()
 
     def copyToClipboard(self):
         clipboard = QGuiApplication.clipboard()
@@ -157,45 +165,79 @@ class FilePicker(QWidget):
         self.lineCountLabel.setText(f'Lines ready to copy: {line_count}')
         self.btnCopy.setEnabled(bool(text))
 
-    def refreshFiles(self):
-        if hasattr(self, 'currentFiles') and self.currentFiles:
-            concatenated_content = self.concatenate_files(self.currentFiles)
-            self.textEdit.setText(concatenated_content)
+    def updateTextEdit(self):
+        if self.currentFiles:
+            file_path = self.currentFiles[0]
+            if file_path.endswith('.py'):
+                _, _, imports, file_content = parse_python_file(file_path)
+                if not self.selected_items:
+                    code = f"# {os.path.basename(file_path)}\n\n```python\n{file_content}\n```"
+                else:
+                    code = extract_code_and_imports(file_content, self.selected_items, file_path)
+            else:
+                # For non-Python files, simply show the entire file content
+                with open(file_path, 'r', encoding='utf-8') as file:
+                    file_content = file.read()
+                    code = f"# {os.path.basename(file_path)}\n\n```{self.detect_language(file_path)}\n{file_content}\n```"
 
-    def dragEnterEvent(self, event: QDragEnterEvent):
-        if event.mimeData().hasUrls():
-            event.acceptProposedAction()
+            self.textEdit.setText(code)
+
+    def detect_language(self, file_path):
+        """Detect the language based on the file extension for syntax highlighting in markdown."""
+        if file_path.endswith('.js'):
+            return 'javascript'
+        elif file_path.endswith(('.ts', '.tsx')):
+            return 'typescript'
         else:
-            event.ignore()
+            return 'plaintext'
 
-    def dropEvent(self, event: QDropEvent):
-        if event.mimeData().hasUrls():
-            files = []
-            for url in event.mimeData().urls():
-                if url.isLocalFile():
-                    files.append(url.toLocalFile())
-            if files:
-                self.fileList.clear()
-                self.currentFiles = files
-                self.refreshFiles()
-                self.btnRefresh.setEnabled(True)
-                self.animateDropSuccess()
-            event.acceptProposedAction()
-        else:
-            event.ignore()
 
-    def applyBrightnessEffect(self):
-        self.effect = QGraphicsColorizeEffect(self)
-        self.effect.setColor(Qt.darkBlue)
-        self.effect.setStrength(0.25)
-        self.setGraphicsEffect(self.effect)
+def parse_python_file(file_path):
+    try:
+        with open(file_path, 'r', encoding='utf-8') as file:
+            file_content = file.read()
+            tree = ast.parse(file_content, filename=file_path)
+    except SyntaxError as e:
+        print(f"Syntax error in file {file_path}: {e}")
+        return [], [], [], ""
 
-    def removeBrightnessEffect(self):
-        self.setGraphicsEffect(None)
+    classes = []
+    functions = []
+    imports = []
 
-    def animateDropSuccess(self):
-        self.applyBrightnessEffect()
-        QTimer.singleShot(100, self.removeBrightnessEffect)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef):
+            classes.append(node.name)
+        elif isinstance(node, ast.FunctionDef):
+            functions.append(node.name)
+        elif isinstance(node, (ast.Import, ast.ImportFrom)):
+            imports.append(ast.get_source_segment(file_content, node))
+
+    return classes, functions, imports, file_content
+
+
+def extract_code_and_imports(file_content, selected_items, file_path):
+    tree = ast.parse(file_content)
+    selected_code = []
+    imports = set()
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            imports.add(ast.get_source_segment(file_content, node))
+
+    imports_str = "\n".join(sorted(imports))
+    file_name = os.path.basename(file_path)
+    header = f"# {file_name}\n\n## Selected Classes/Functions: {', '.join(selected_items)}\n"
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.ClassDef, ast.FunctionDef)) and node.name in selected_items:
+            start_line = node.lineno - 1
+            end_line = node.end_lineno
+            code_block = "\n".join(file_content.splitlines()[start_line:end_line])
+            reference_path = f"{file_path.replace('/', '.')}.{node.name}"
+            selected_code.append(f"### `{reference_path}`\n\n```python\n{code_block}\n```\n")
+
+    return f"{header}\n```python\n{imports_str}\n```\n\n" + "\n".join(selected_code)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Initial implementation of ability to select classes and functions from files.
- Supports original case of selecting multiple files and seeing all their code together in markdown 
- Supports selection of functions / classes from any number of selected files.
- Provides full, sanitized paths to files and symbols

### Errata
- Symbol selection only supported on python files
- Symbol selection does not nest functions under classes

Fixes #5