### PR TITLE
Add Homebrew-Based Installation for FileKitty

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,123 +2,124 @@
 
 <img src="https://github.com/banagale/FileKitty/assets/1409710/d7c68e71-5245-499b-8be9-3ca1f88adc1b" width="200">
 
-A simple macOS utility to select, combine, and copy file contents, especially useful for providing context to **Large
-Language Models (LLMs)** and **Generative AI** coding assistants. Includes history tracking.
+A macOS utility for selecting, combining, and copying the contents of files — ideal for use with **LLMs and generative AI tools**. FileKitty lets you
+grab context from multiple files with one click and keeps a full history of your selections.
 
-## Features
+---
 
-- Select files from a directory or via drag-and-drop from Finder Pycharm (jetbrains IDEs) project navigation, etc.
-- Display concatenated content from selected files, formatted for easy copying.
-- Smartly extract specific Python classes/functions.
-- **Navigate history**: Use Back/Forward buttons to revisit previous file selections and generated text outputs.
-- **Detect stale content**: Indicates if file contents have changed on disk since a history state was captured.
-- Copy generated text to the clipboard with one click.
-- Configurable default directory for file selection.
-- Configurable storage location for temporary history snapshots.
+## Use Cases
 
-## Good for
+- Gather code snippets for LLM prompts (ChatGPT, Claude, Gemini, Copilot, etc.)
+- Provide precise multi-file context for generative AI tools
+- Combine logs, configs, or structured docs for inspection
+- Track and revisit prior file selections and outputs
 
-- **LLM Context**: Easily gathering code snippets or text from multiple files to paste into LLM prompts (like ChatGPT,
-  Claude, Gemini, Copilot etc.).
-- **Generative AI Coding**: Providing accurate, multi-file context to AI coding tools.
-- Quickly combining log files or text snippets.
-- Reviewing previous sets of files and their combined content via history.
+---
 
-## How to use it
-
-**Basic Concatenation for LLM Context:**
-
-1. Open the FileKitty app.
-2. Click **📂 Select Files** or **drag and drop** the source code or text files you need onto the app window.
-   *(Example selecting files)*
-   <img src="https://github.com/user-attachments/assets/5596d32e-52b3-4791-90eb-32ba0def3162" width="741">
-3. The content from the selected files will appear combined in the main text area, formatted with Markdown code blocks (
-   e.g., ```python ... ```).
-4. Click **📋 Copy to Clipboard**.
-5. Paste the combined content directly into your LLM chat or generative AI prompt.
-   *(Example text area and copy button)*
-   <img src="https://github.com/user-attachments/assets/b95a981e-673d-4df1-ad2f-cb92cd3fc416" width="800">
-
-**Using History:**
-
-- Each time you change the file selection, Python symbol selection, or refresh, a history state is saved (if the text
-  output differs).
-- Use the **◀ Back** and **▶ Forward** buttons in the toolbar to step through past states.
-- The toolbar shows your current position (e.g., "History 3 of 5").
-- An indicator like `(Modified)` or `(Missing Files)` appears if the source files on disk no longer match the state you
-  are viewing.
-
-**Selecting Python Symbols:**
-
-- If only Python (`.py`) files are selected, click **🔍 Select Classes/Functions**.
-- Choose specific symbols; the text area will update to show only those, plus relevant imports – useful for focusing LLM
-  context.
-
-**Refreshing Content:**
-
-- Click **🔄 Refresh** to reload content from the files currently listed. This is useful if you edit files outside the
-  app.
-
-## Preferences
-
-- Access via the "FileKitty" menu (Cmd+,).
-- **Default 'Select Files' Directory**: Set the starting folder for the file dialog.
-- **History Storage Directory**: Choose where FileKitty saves temporary history snapshots. Defaults to the system
-  temporary location. Changing this clears existing history.
-
-## Build
-
-### Prerequisites
-
-- Requires macOS.
-- [Poetry](https://python-poetry.org/docs/) is used for dependency management and building.
-
-### Build from source
+## Quick Install (macOS via Homebrew)
 
 ```bash
-# Clone the repository
-# cd FileKitty
+brew install banagale/filekitty/filekitty
+```
+
+Launch from **Applications** or from terminal with simply: `filekitty`
+
+## Install via build 
+See Manual Build section below.
+
+---
+
+
+## Screenshots
+
+*Select files, preview combined output, copy instantly*
+
+<img src="https://github.com/user-attachments/assets/5596d32e-52b3-4791-90eb-32ba0def3162" width="741">
+<img src="https://github.com/user-attachments/assets/b95a981e-673d-4df1-ad2f-cb92cd3fc416" width="800">
+
+---
+
+## How to Use
+
+1. **Open the app**
+2. **Select Files** or drag-and-drop files from Finder, PyCharm, etc.
+3. Combined contents will appear, grouped in Markdown code blocks.
+4. Click **Copy to Clipboard** and paste into your LLM or chat.
+
+### History Navigation
+
+- Back/Forward buttons let you navigate prior selections
+- Changes to file contents are detected and marked as `(Modified)` or `(Missing Files)`
+
+### Python Symbol Mode
+
+- When `.py` files are selected, use **Select Classes/Functions** to target specific symbols and relevant imports.
+
+### Refreshing
+
+- Click **Refresh** to reload the current selection, useful after editing source files.
+
+### Preferences
+
+Access via **FileKitty → Preferences** (`Cmd+,`):
+
+- **Default Select Directory** – sets initial folder for file dialog
+- **History Location** – controls where snapshot state is stored
+
+---
+
+##️ Developer & Contributor Guide
+
+### Manual Build 
+
+Install [Poetry](https://python-poetry.org/):
+
+```bash
+git clone https://github.com/banagale/FileKitty.git
+cd FileKitty
 poetry install
 poetry run python setup.py py2app
 ```
 
-- The application bundle (`FileKitty.app`) will be in `./dist/`.
-- Copy `FileKitty.app` to your `/Applications` folder.
+The app bundle will be created in `./dist/`. Copy it to `/Applications` to use it like a regular app.
 
-## Linting and Formatting
+> Manual builds may assist in testing or adapting for Linux/Windows.
 
-This project uses [Ruff](https://docs.astral.sh/ruff/) for linting and code formatting.
+---
 
-### Run locally
+### Linting & Formatting
+
+Uses [Ruff](https://docs.astral.sh/ruff/):
 
 ```bash
-make lint      # Check for lint issues
+make lint      # Run linter
 make format    # Format code
-```
 
-Or using poetry directly:
-
-```bash
+# or directly
 poetry run ruff check .
 poetry run ruff format .
 ```
 
-## Contributing
+---
 
-### Pre-commit hooks
+### Pre-commit Hooks
 
-This project uses [pre-commit](https://pre-commit.com/) to enforce linting before each commit.
-
-To set it up locally:
+Set up local linting before commits:
 
 ```bash
-poetry install  # If not already done
 pre-commit install
-# Optional: check everything right away
 pre-commit run --all-files
 ```
 
-## Continuous Integration
+---
 
-- **Linting**: Enforced via GitHub Actions on every push and pull request. See `.github/workflows/lint.yml`.
-- **Build Validation**: Ensures the app builds correctly on macOS. See `.github/workflows/build.yml`.
+### Continuous Integration
+
+- GitHub Actions validate linting and build on every push
+- See `.github/workflows/` for full pipeline
+
+---
+
+## License
+
+MIT License © Rob Banagale

--- a/filekitty/app.py
+++ b/filekitty/app.py
@@ -788,9 +788,9 @@ class FilePicker(QWidget):
 
             # Check if the selection state actually changed
             state_changed = (
-                    set(new_selected_items) != old_selected_items
-                    or new_mode != old_mode
-                    or new_file != old_file  # Comparing paths directly
+                set(new_selected_items) != old_selected_items
+                or new_mode != old_mode
+                or new_file != old_file  # Comparing paths directly
             )
 
             if state_changed:
@@ -843,7 +843,7 @@ class FilePicker(QWidget):
             if str_path.startswith(str_home):
                 # Ensure a path separator follows the home dir part before replacing
                 if len(str_path) > len(str_home) and str_path[len(str_home)] in (os.sep, os.altsep):
-                    return "~" + str_path[len(str_home):]
+                    return "~" + str_path[len(str_home) :]
                 elif len(str_path) == len(str_home):  # Exact match to home dir
                     return "~"
             # If not relative to home, return the absolute path
@@ -903,12 +903,8 @@ class FilePicker(QWidget):
                     # Does this file contain any of the globally selected items?
                     relevant_items_exist_in_file = any(item in items_in_this_file for item in self.selected_items)
 
-                    should_filter_this_file = (
-                            is_filtered
-                            and (
-                                    self.selection_mode == "Single File"
-                                    or relevant_items_exist_in_file
-                            )
+                    should_filter_this_file = is_filtered and (
+                        self.selection_mode == "Single File" or relevant_items_exist_in_file
                     )
 
                     if should_filter_this_file:
@@ -1113,7 +1109,7 @@ class FilePicker(QWidget):
             # Manage history list: remove future states if branching
             if self.history_index < len(self.history) - 1:
                 # Remove states after the current one
-                states_to_remove = self.history[self.history_index + 1:]
+                states_to_remove = self.history[self.history_index + 1 :]
                 self.history = self.history[: self.history_index + 1]
                 # Delete the corresponding JSON files
                 for old_state in states_to_remove:
@@ -1496,13 +1492,13 @@ class CodeExtractor(ast.NodeVisitor):
             else:
                 # Multi-line segment
                 first_line = self.file_content_lines[start_line][start_col:]
-                middle_lines = self.file_content_lines[start_line + 1: end_line]
+                middle_lines = self.file_content_lines[start_line + 1 : end_line]
                 last_line = self.file_content_lines[end_line][:end_col]
                 # Ensure consistent newline endings
                 code_lines = (
-                        [first_line.rstrip("\r\n")]
-                        + [line.rstrip("\r\n") for line in middle_lines]
-                        + [last_line.rstrip("\r\n")]
+                    [first_line.rstrip("\r\n")]
+                    + [line.rstrip("\r\n") for line in middle_lines]
+                    + [last_line.rstrip("\r\n")]
                 )
                 return "\n".join(code_lines)
         except IndexError:


### PR DESCRIPTION
Fixes #31.

Most of the changes to handle this issue were performed in the creation and commits to the new repo, https://github.com/banagale/homebrew-filekitty/

While adding the new instructions, I took the opportunity to streamline the readme as well.

```
brew install banagale/filekitty/filekitty
```

or

```
brew tap banagale/filekitty
brew install filekitty
```

The first, one-liner version was added in this readme update.
